### PR TITLE
Optimize for speed ... for fun because there is no real profit

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,15 @@ If you **soldered a perfboard** yourself (one with letters on the long side):
   - because 1 rotation = 4 * number of pulse per revolution = events
   - to chose your encoder PPR, check `desired_RPM * PPR < 1 500 000`
 
+# Error codes
+
+  - `E003`, `E006`, `E009`, `E012`, or any error cumulated error from `1` to `15`
+    - Cause : this meands a quadrature encoder error because steps were missed
+    - Problem : rotation speed was too high, in DEGREE or RAW mode
+    - Solutions
+      - clear the error by pressing the button (returns to RPM mode)
+      - remember to switch to RPM mode *before* starting spindle motor !
+
 # Components
 
 For this project, you will need :
@@ -204,6 +213,12 @@ And see [Bill of materials](BOM.csv) for others components :
 - terminals
 
 # Requirements
+
+- Memory
+  - without any features : ~3700 bytes required
+  - with USE_Z_RESET : ~80 more bytes required
+  - so up to here, a 4K flash MCU without bootloader or with a 256-bytes bootloader would work
+  - for all features : ~5900 bytes required, so that usually means an 8K flash
 
 - Electrical characteristics
   - 5V power supply (adapt the display resistors in case of a 3.3V MCU)

--- a/README.md
+++ b/README.md
@@ -236,10 +236,13 @@ And see [Bill of materials](BOM.csv) for others components :
 
 # Installation
 
-- Clone the project
-- Open in arduino IDE
+- Clone the project and open in arduino IDE
+- Optional : install `digitalWriteFast` library
+  - Uncomment the `USE_FAST_LIBRARY` define at the top of the INO file
+
 - Option 1 : Using an UNO-as-ISP and breadboard schematic
   - use Sketch / Upload using programmer
+
 - Option 2 : install Minicore or better bootloader and fuse management, and upload over serial
   - Follow https://github.com/MCUdude/MiniCore?tab=readme-ov-file#how-to-install
   - Prepare/Configure your board

--- a/README.md
+++ b/README.md
@@ -237,8 +237,7 @@ And see [Bill of materials](BOM.csv) for others components :
 # Installation
 
 - Clone the project and open in arduino IDE
-- Optional : install `digitalWriteFast` library
-  - Uncomment the `USE_FAST_LIBRARY` define at the top of the INO file
+- REQUIRED : install `digitalWriteFast` library
 
 - Option 1 : Using an UNO-as-ISP and breadboard schematic
   - use Sketch / Upload using programmer

--- a/arduino_spindle_encoder.ino
+++ b/arduino_spindle_encoder.ino
@@ -573,7 +573,7 @@ private:
   const Encoder& encoder;
   volatile uint8_t state;
   volatile CONFIG_ENCODER_COUNTER_TYPE counter;
-  uint32_t relative_zero;
+  CONFIG_ENCODER_COUNTER_TYPE relative_zero;
   volatile uint8_t error_flag;
 #if defined(USE_Z_RESET)
   volatile bool homing_canary;

--- a/arduino_spindle_encoder.ino
+++ b/arduino_spindle_encoder.ino
@@ -414,16 +414,18 @@ public:
   typedef void (*IsrFunc)(void);
 
   Encoder(
-    const uint16_t pulse_per_revolution,
+    const uint16_t pulse_per_revolution
 #if defined(USE_Z_RESET)
+    ,
     const uint8_t pin_z_active_state
 #endif  // USE_Z_RESET
     )
     : pulse_per_revolution(pulse_per_revolution),
       // Encoder count of A/B signal *changes* in a single turn
       // = max raw value before over/under flowing
-      raw_value_range(pulse_per_revolution << 2),
+      raw_value_range(pulse_per_revolution << 2)
 #if defined(USE_Z_RESET)
+      ,
       pin_z_active_state(pin_z_active_state)
 #endif  // USE_Z_RESET
   {
@@ -694,8 +696,9 @@ private:
 /************************* Global variables (required for interrupts) *************************/
 
 Encoder global_encoder(
-  CONFIG_ENCODER_PULSES_PER_REVOLUTION,
+  CONFIG_ENCODER_PULSES_PER_REVOLUTION
 #if defined(USE_Z_RESET)
+  ,
   CONFIG_PIN_IN_QUAD_Z_ACTIVE_STATE
 #endif  // USE_Z_RESET
 );

--- a/arduino_spindle_encoder.ino
+++ b/arduino_spindle_encoder.ino
@@ -498,7 +498,7 @@ public:
     const int8_t delta = (int8_t)result & 0b00000111;
     counter += delta - 1;
     if (result > CW) {
-      const uint8_t error = (uint8_t)result >> 3;
+      const uint8_t error = (result >> 3) & 0b00001111;
       error_flag |= error;
     }
 #if defined(USE_Z_RESET)

--- a/arduino_spindle_encoder.ino
+++ b/arduino_spindle_encoder.ino
@@ -509,10 +509,14 @@ public:
 #endif  // USE_Z_RESET
   }
 
-  void setup() {
+  void initialize_state() {
     // build a valid state from two reads
     update_state_from_inputs();
     update_state_from_inputs();
+  }
+
+  void setup() {
+    initialize_state();
   }
 
   void clear_counter() {
@@ -537,6 +541,7 @@ public:
   }
 
   void clear_error() {
+    initialize_state();
     error_flag = 0;
   }
 


### PR DESCRIPTION
**IMPORTANT**: The quadrature ISR timings are not important anyway, as you are *NOT* meant to turn the spindle on when in DEGREE/RAW mode. When the spindle is on, you should be in RPM mode, where 4 times less interrupts are produced, and its code is the simplest one (increment a counter). So the optimization below is mainly to learn how to better code on these microcontrollers, not for real advantage.

Optimization... so just for fun, as stated above.
- Used direct pin manipulations
- Reduced the number of clock cycles of quadrature update
- Implemented optional timing to verify its effect
- Confirmed the optimization using ISR waveforms on scope

See comments in `time_sensitive_functions()` results on Atmega8A.

Still kept a 32-bit quadrature counter :
- i believe it is more resilient when used in sporadic loop operations
- you can use CONFIG_ENCODER_COUNTER_TYPE to switch to 16-bit counter
- using a 16-bit counter would save 23 clock cycle per ISR call.

To summarize the results:
- on the Atmega8A i am using, the overall limiting factor is the minimum time **between** interrupts anyway : ~5.5us
- in RPM mode, the microcontroller has no problem tracking speed up to 1150 RPM (my lathe does not go faster)
- in DEG/RAW mode (_just to test, because this is useless and stupid..._) the quadrature ISR and display works up to 360 RPM